### PR TITLE
Implemented functionality for table lineage creation by querying a particular task.

### DIFF
--- a/restAPI/helper_functions/kafka-helper-functions.js
+++ b/restAPI/helper_functions/kafka-helper-functions.js
@@ -84,7 +84,7 @@ async function createDagNode(dagId) {
 
 /**
  * Function to persist "is_parent_of" relationship between Dag and Task on Neo4j
- * @param {String} dagId - The ID of the parent Dag 
+ * @param {String} dagId - The ID of the parent Dag
  * @param {String} taskId - The ID of the task belonging to the parent Dag
  */
 async function createDagTaskRelationship(dagId, taskId) {
@@ -198,11 +198,13 @@ async function createSparkJobNode(sparkJobId) {
       });
     })
     .catch((err) => {
-      console.log("Error when creating: " + sparkJobId + " Error message: " + err);
+      console.log(
+        "Error when creating: " + sparkJobId + " Error message: " + err
+      );
     });
 }
 
-async function createTaskSparkJobRelationship(taskId, sparkJobId){
+async function createTaskSparkJobRelationship(taskId, sparkJobId) {
   producer
     .connect()
     .then(() => {
@@ -243,7 +245,10 @@ async function createTaskSparkJobRelationship(taskId, sparkJobId){
     });
 }
 
-async function createSparkJobSparkTaskRelationship(parentSparkJobId, sparkTaskId){
+async function createSparkJobSparkTaskRelationship(
+  parentSparkJobId,
+  sparkTaskId
+) {
   producer
     .connect()
     .then(() => {
@@ -366,6 +371,87 @@ async function createSparkTaskToDatasetRelationship(sparkTaskId, datasetId) {
     });
 }
 
+async function createDatasetToTaskRelationship(datasetId, taskId) {
+  producer
+    .connect()
+    .then(() => {
+      console.log("SENDING CREATEDATASETTOTASKRS MESSAGE TO Q");
+      producer.send({
+        topic: "test",
+        messages: [
+          {
+            value: JSON.stringify({
+              op: "merge",
+              properties: {},
+              rel_type: "used_in",
+              from: {
+                ids: { datasetId },
+                labels: ["Dataset"],
+                op: "merge",
+              },
+              to: {
+                ids: { taskId },
+                labels: ["Task"],
+                op: "merge",
+              },
+              type: "relationship",
+            }),
+          },
+        ],
+      });
+    })
+    .catch((err) => {
+      console.log(
+        "Error when creating: " +
+          datasetId +
+          " to " +
+          taskId +
+          " Error message: " +
+          err
+      );
+    });
+}
+
+async function createTaskToDatasetRelationship(taskId, datasetId) {
+  producer
+    .connect()
+    .then(() => {
+      console.log("SENDING CREATETASKDATASETRS MESSAGE TO Q");
+      producer.send({
+        topic: "test",
+        messages: [
+          {
+            value: JSON.stringify({
+              op: "merge",
+              properties: {},
+              rel_type: "outputs_to",
+              from: {
+                ids: { taskId },
+                labels: ["Task"],
+                op: "merge",
+              },
+              to: {
+                ids: { datasetId },
+                labels: ["Dataset"],
+                op: "merge",
+              },
+              type: "relationship",
+            }),
+          },
+        ],
+      });
+    })
+    .catch((err) => {
+      console.log(
+        "Error when creating: " +
+          taskId +
+          " to " +
+          datasetId +
+          " Error message: " +
+          err
+      );
+    });
+}
 
 module.exports = {
   setupKafkaConnect,
@@ -376,5 +462,7 @@ module.exports = {
   createSparkJobSparkTaskRelationship,
   createTaskSparkJobRelationship,
   createDatasetToSparkTaskRelationship,
-  createSparkTaskToDatasetRelationship
+  createSparkTaskToDatasetRelationship,
+  createDatasetToTaskRelationship,
+  createTaskToDatasetRelationship,
 };

--- a/restAPI/server.js
+++ b/restAPI/server.js
@@ -580,6 +580,9 @@ app.get("/airflow/tablelineagetask/:taskId", function (req, res) {
  * Sample of dataset queries:
  * http://localhost:5000/api/v1/lineage?nodeId=dataset:postgres://postgres:5432/airflow:page_categories
  * http://localhost:5000/api/v1/lineage?nodeId=dataset:file:/usr/local/spark/app/output/result2.parquet
+ *
+ * But query does not process when the following endpoint is called
+ * http://localhost:3001/airflow/tablelineagedataset/file:/usr/local/spark/app/output/result2.parquet
  **/
 //NOT WORKING AT THE MOMENT.
 app.get("/airflow/tablelineagedataset/:datasetId", function (req, res) {


### PR DESCRIPTION
Implementation to create table lineage by querying a dataset to be fixed. Issue is the datasetID which is dependent on the namespace, but it can vary if it's from a database / if it's a local file. Ideal to find a way to query the namespace of the dataset it is from.

In addition, the names of the datasets often include '/' to indicate the path of the dataset. Not sure if it messes up the URL endpoint E.g 
`http://localhost:3001/airflow/tablelineagedataset/file:/usr/local/spark/app/output/result2.parquet`
Where `file:/usr/local/spark/app/output/result2.parquet` is the datasetId.